### PR TITLE
Add support for better-sqlite3 as alternative to standard sqlite

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-
-npm run test

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -234,7 +234,8 @@ module.exports = ({env}) => ({
 
 ### sqlite3Executable
 
-- Required your strapi database client is `sqlite`
+- Required if your strapi database client is `sqlite` and `better-sqlite3` node module is not available/wanted.
+  Using `better-sqlite3`removes the sqlite dependency on the machine and uses an already existing dependency of strapi but results in a bigger file size because of a binary database file beeing exported compared to the default text file of sql.
 - Array
 
 ```js

--- a/server/configuration/config.js
+++ b/server/configuration/config.js
@@ -14,6 +14,15 @@ const throwConfigInvalidValueError = (configKey, invalidValue) => {
   );
 }
 
+const isBetterSqlite3Available = () => {
+  try {
+    require.resolve('better-sqlite3');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 const requiredConfigKeys = [
   'awsAccessKeyId',
   'awsSecretAccessKey',
@@ -152,7 +161,7 @@ const customValidatorByRequiredConfigKey = {
     if (config.disableDatabaseBackup || config.databaseDriver !== StrapiDatabaseDriver.SQLITE)
       return;
 
-    if (typeof config.sqlite3Executable !== 'string') {
+    if (typeof config.sqlite3Executable !== 'string' && !isBetterSqlite3Available) {
       // @todo check if path exists
       throwConfigInvalidValueError('sqlite3Executable', config.sqlite3Executable);
     }


### PR DESCRIPTION
When using sqlite with strapi the dependency of node based `better-sqlite3` already persists. To remove the need of installing sqlite on the remote server just to use the sqlite backup, I added the possibility to use the `better-sqlite3`.backup feature for the database export.

The check for the sqlite executable was extended.
If the executable is not given in the config but `better-sqlite3` is available, it will use the `better-sqlite3` instead of throwing an error.

The exported file is bigger due to the filetype beeing a binary database file than just the text file of the sqlite.dump.
For me it was about twice the size.