### PR TITLE
Add native Strapi Export functionallity

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-
-npm run test

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -128,7 +128,7 @@ module.exports = ({env}) => ({
 ### databaseDriver
 
 - Required
-- String (`sqlite` or `postgres` or `mysql`)
+- String (`sqlite` or `postgres` or `mysql` `strapi-export`)
 - Default : environment variable `DATABASE_CLIENT`
 
 ```js
@@ -251,6 +251,33 @@ module.exports = ({env}) => ({
 ```
 
 [Learn more about sqlite3](https://www.sqlite.org/cli.html)
+
+### strapiExportOptions
+
+- Required if you want to use `strapi-export`
+- Type: Object
+
+Options to be passed to the strapi export command. This allows you to customize the export process based on the available options in Strapi. A key is required or `no-encrypt` set to true.
+
+```js
+// ./config/plugins.js
+
+module.exports = ({env}) => ({
+  backup: {
+    enabled: true,
+    config: {
+      strapiExportOptions: {
+        only: 'content-types', // String: Export only specific type. Available Options: `content`, `files`, `config`
+        exclude: 'files', // String: Allows to exlude `content`, `files`, `configuration`. Multiple options possible with comma separation.
+        'no-encrypt': false, // Boolean: Disable default encryption.
+        key: 'my-encryption-key' // String: To use encryption an encryption key is needed.
+      }
+    }
+  }
+});
+```
+
+[Learn more about strapi Export](https://docs.strapi.io/dev-docs/data-management/export)
 
 ### customDatabaseBackupFilename
 

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -256,8 +256,12 @@ module.exports = ({env}) => ({
 
 - Required if you want to use `strapi-export`
 - Type: Object
+- Default: `strapiExportOptions: {'no-encrypt': true, exclude: 'files}`
 
-Options to be passed to the strapi export command. This allows you to customize the export process based on the available options in Strapi. A key is required or `no-encrypt` set to true.
+Options to be passed to the strapi export command. This allows you to customize the export process based on the available options in Strapi.
+Add a key if you want to encrypt the export.
+
+Learn more about Strapi Export an the export options in the [official docs](https://docs.strapi.io/dev-docs/data-management/export)
 
 ```js
 // ./config/plugins.js
@@ -267,17 +271,16 @@ module.exports = ({env}) => ({
     enabled: true,
     config: {
       strapiExportOptions: {
-        only: 'content-types', // String: Export only specific type. Available Options: `content`, `files`, `config`
-        exclude: 'files', // String: Allows to exlude `content`, `files`, `configuration`. Multiple options possible with comma separation.
-        'no-encrypt': false, // Boolean: Disable default encryption.
-        key: 'my-encryption-key' // String: To use encryption an encryption key is needed.
+        only: 'content-types', // Optional String: Export only specific type. Available Options: `content`, `files`, `config`
+        exclude: 'files', // Optional String: Allows to exlude `content`, `files`, `configuration`. Multiple options possible with comma separation.
+        'no-encrypt': false, // Optional Boolean: Disable default encryption.
+        key: 'my-encryption-key' // Optional String: To use encryption an encryption key is needed.
       }
     }
   }
 });
 ```
 
-[Learn more about strapi Export](https://docs.strapi.io/dev-docs/data-management/export)
 
 ### customDatabaseBackupFilename
 

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -256,7 +256,7 @@ module.exports = ({env}) => ({
 
 - Required if you want to use `strapi-export`
 - Type: Object
-- Default: `strapiExportOptions: {'no-encrypt': true, exclude: 'files}`
+- Default: `strapiExportOptions: {'no-encrypt': true}`
 
 Options to be passed to the strapi export command. This allows you to customize the export process based on the available options in Strapi.
 Add a key if you want to encrypt the export.

--- a/server/backend/services/backup.js
+++ b/server/backend/services/backup.js
@@ -33,6 +33,19 @@ module.exports = ({ strapi }) => {
     return new Promise((resolve, reject) => {
       const tmpArchiveFilePath = createTmpFilename();
 
+      // if the databaseDriver is set to STRAPI_EXPORT, we don't need to create an archive
+      if (backupConfig.databaseDriver === StrapiDatabaseDriver.STRAPI_EXPORT) {
+        storageService.put(
+          fs.createReadStream(`${filePath}.tar.gz`),
+          `${backupFilename}.tar.gz`
+        ).then(() => {
+          resolve();
+          fs.unlinkSync(`${filePath}.tar.gz`);
+        }).catch(reject);
+        return;
+      }
+
+      // else, create an archive from the dumped database file
       createArchive(filePath, tmpArchiveFilePath)
         .then(() => {
           return storageService.put(

--- a/server/backend/services/backup.js
+++ b/server/backend/services/backup.js
@@ -3,7 +3,7 @@
 const fs = require("fs");
 
 const {
-  createDatabaseDumperFromConfig
+  createDatabaseDumperFromConfig, StrapiDatabaseDriver
 } = require("../../../internal/db-dump");
 
 const {
@@ -58,10 +58,24 @@ module.exports = ({ strapi }) => {
     ) => {
       return new Promise((resolve, reject) => {
         const databaseDumpOutputFilename = createTmpFilename();
-        const databaseDumper = createDatabaseDumperFromConfig({
-          ...backupConfig,
-          ...createBackupDatabaseConnectionConfigFromStrapi(strapi)
-        });
+        const { databaseDriver } = backupConfig;
+
+        let mergedConfig;
+
+        if (databaseDriver === StrapiDatabaseDriver.STRAPI_EXPORT) {
+          mergedConfig = {
+            ...backupConfig,
+            ...createBackupDatabaseConnectionConfigFromStrapi(strapi),
+            databaseDriver
+          };
+        } else {
+          mergedConfig = {
+            ...backupConfig,
+            ...createBackupDatabaseConnectionConfigFromStrapi(strapi)
+          }
+        }
+        
+        const databaseDumper = createDatabaseDumperFromConfig(mergedConfig);
 
         databaseDumper.dump(databaseDumpOutputFilename)
           .then(() => {

--- a/server/configuration/config.js
+++ b/server/configuration/config.js
@@ -112,6 +112,22 @@ const customValidatorByRequiredConfigKey = {
   databaseDriver: (config) => {
     if (!Object.values(StrapiDatabaseDriver).includes(config.databaseDriver)) {
       throwConfigInvalidValueError('databaseDriver', config.databaseDriver);
+      return;
+    }
+
+    if (config.databaseDriver === StrapiDatabaseDriver.STRAPI_EXPORT) {
+      if (!Object.keys(config).includes('strapiExportOptions')) {
+        throwConfigInvalidValueError('strapiExportOptions', config.strapiExportOptions);
+        return
+      }
+
+      if (!Object.keys(config.strapiExportOptions).includes('key')) {
+        if (!config.strapiExportOptions['no-encrypt']) {
+          throw new Error('Strapi Export needs a valid key:string in the strapiExportOptions or no-encrypt set to true');
+        }
+      } else if (typeof config.strapiExportOptions.key !== 'string') {
+        throwConfigInvalidValueError('strapiExportOptions.key', config.strapiExportOptions.key)
+      }
     }
   },
   gcsBucketName: (config) => {
@@ -179,6 +195,7 @@ module.exports = {
     databaseDriver: env('DATABASE_CLIENT'),
     mysqldumpOptions: [],
     pgDumpOptions: [],
+    strapiExportOptions: {},
     allowCleanup: false,
     timeToKeepBackupsInSeconds: undefined,
     cleanupCronSchedule: undefined,

--- a/server/configuration/config.js
+++ b/server/configuration/config.js
@@ -190,7 +190,6 @@ module.exports = {
     pgDumpOptions: [],
     strapiExportOptions: {
       'no-encrypt': true,
-      exclude: 'files',
     },
     allowCleanup: false,
     timeToKeepBackupsInSeconds: undefined,

--- a/server/configuration/config.js
+++ b/server/configuration/config.js
@@ -116,17 +116,10 @@ const customValidatorByRequiredConfigKey = {
     }
 
     if (config.databaseDriver === StrapiDatabaseDriver.STRAPI_EXPORT) {
-      if (!Object.keys(config).includes('strapiExportOptions')) {
-        throwConfigInvalidValueError('strapiExportOptions', config.strapiExportOptions);
-        return
-      }
-
-      if (!Object.keys(config.strapiExportOptions).includes('key')) {
-        if (!config.strapiExportOptions['no-encrypt']) {
+      if (typeof config.strapiExportOptions?.key !== 'string') {
+        if (!config.strapiExportOptions?.['no-encrypt']) {
           throw new Error('Strapi Export needs a valid key:string in the strapiExportOptions or no-encrypt set to true');
         }
-      } else if (typeof config.strapiExportOptions.key !== 'string') {
-        throwConfigInvalidValueError('strapiExportOptions.key', config.strapiExportOptions.key)
       }
     }
   },
@@ -195,7 +188,10 @@ module.exports = {
     databaseDriver: env('DATABASE_CLIENT'),
     mysqldumpOptions: [],
     pgDumpOptions: [],
-    strapiExportOptions: {},
+    strapiExportOptions: {
+      'no-encrypt': true,
+      exclude: 'files',
+    },
     allowCleanup: false,
     timeToKeepBackupsInSeconds: undefined,
     cleanupCronSchedule: undefined,


### PR DESCRIPTION
The standard database exports needs quite some work during the restore process.

With the native `strapi export` feature we could use the `strapi import` for a later restore process which is more user friendly.