### PR TITLE
Extend cleanup functionality with retention

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -8,4 +8,3 @@ if [ -s "$NVM_DIR/nvm.sh" ]; then
 fi
 
 npm run test
-npm run test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,11 @@
 #!/usr/bin/env sh
 
+#check for nvm and set paths
+export NVM_DIR="$HOME/.nvm"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+    \. "$NVM_DIR/nvm.sh"  # This loads NVM
+    [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+fi
+
+npm run test
 npm run test

--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ module.exports = ({env}) => {
           '--dump-date'
         ],
         allowCleanup: true,
-        timeToKeepBackupsInSeconds: 172800, // 2 days
+        cleanupPolicies: {
+        days: 30 // required, keep backups for this amount of days
+        weeks: 12, // optional, keep a backup per week for this amount of weeks
+        months: 12 // optional, keep a backup per month for this amount of months
+      },
         cleanupCronSchedule: '0 9 * * *', // Each day at 09:00 AM
         errorHandler: (error, strapi) => {
           console.log(error);

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -349,9 +349,9 @@ module.exports = ({env}) => ({
 });
 ```
 
-### timeToKeepBackupsInSeconds
+### timeToKeepBackupsInSeconds (deprecated)
 
-- Required if `allowCleanup` is `true`
+- deprecated, use cleanupPolicies instead
 - Number
 
 ```js
@@ -362,6 +362,31 @@ module.exports = ({env}) => ({
     enabled: true,
     config: {
       timeToKeepBackupsInSeconds: 172800, // Keeps backups for 2 days
+    }
+  }
+});
+```
+
+
+### cleanupPolicies
+
+- Required if `allowCleanup` is `true`
+- Object
+
+Allows to use backup retention to keep backups for a longer time without need for large storage. First key `days` is required and will keep all the backups made for that time period. `weekly` and `monthly` will keep oldest backup per week/month for set amount of time.
+
+```js
+// ./config/plugins.js
+
+module.exports = ({env}) => ({
+  backup: {
+    enabled: true,
+    config: {
+      cleanupPolicies: {
+        days: 30 // required, keep backups for this amount of days
+        weeks: 12, // optional, keep a backup per week for this amount of weeks
+        months: 12 // optional, keep a backup per month for this amount of months
+      },
     }
   }
 });

--- a/internal/utils.js
+++ b/internal/utils.js
@@ -33,9 +33,26 @@ const dateDiffInSeconds = (date1, date2) => {
   return Math.abs((date2.getTime() - date1.getTime()) / 1000);
 };
 
+const getBackupsToKeep = (backups, periodInSeconds) => {
+  const uniqueBackups = [];
+  const seenPeriods = new Set();
+
+  backups.forEach(backupFile => {
+    const period = Math.floor(backupFile.date.getTime() / 1000 / periodInSeconds);
+
+    if (!seenPeriods.has(period)) {
+      uniqueBackups.push(backupFile);
+      seenPeriods.add(period);
+    }
+  });
+
+  return uniqueBackups;
+};
+
 module.exports = {
   createArchive,
   createTmpFilename,
   dateDiffInSeconds,
+  getBackupsToKeep,
   tmpDir
 }

--- a/server/backend/services/backup.js
+++ b/server/backend/services/backup.js
@@ -56,8 +56,6 @@ module.exports = ({ strapi }) => {
     const dailyLimit = policies.days ? policies.days * 86400 : policies;
     const weeklyLimit = policies.weeks * 604800; // Convert to seconds
     const monthlyLimit = policies.months * 2592000; // Convert to seconds
-
-    console.log('dailyLimit:', dailyLimit);
   
     const dailyBackups = [];
     const weeklyBackups = [];
@@ -65,8 +63,6 @@ module.exports = ({ strapi }) => {
   
     backups.forEach(backupFile => {
       const timeDifferenceInSeconds = (now - backupFile.date) / 1000;
-
-      console.log('age in seconds:', timeDifferenceInSeconds);
   
       if (timeDifferenceInSeconds <= dailyLimit) {
         dailyBackups.push(backupFile);
@@ -76,17 +72,10 @@ module.exports = ({ strapi }) => {
         monthlyBackups.push(backupFile);
       }
     });
-
-    console.log('1minutely:', dailyBackups);
-    console.log('30minutely:', weeklyBackups);
-    console.log('hourly:', monthlyBackups);
   
     // Select unique backups for weekly and monthly periods
     const weeklyBackupsToKeep = getBackupsToKeep(weeklyBackups, 1800);
     const monthlyBackupsToKeep = getBackupsToKeep(monthlyBackups, 3600);
-
-    console.log('30minutelyToKeep:', weeklyBackupsToKeep);
-    console.log('hourlyToKeep:', monthlyBackupsToKeep);
   
     const backupsToDelete = backups.filter(backupFile =>
       !dailyBackups.includes(backupFile) &&
@@ -132,7 +121,6 @@ module.exports = ({ strapi }) => {
         .then(backups => {
           const backupsToDelete = applyCleanupPolicies(backups, backupConfig.cleanupPolicies || backupConfig.timeToKeepBackupsInSeconds);
           const backupNamesToDelete = backupsToDelete?.flatMap((backup) => backup.name);
-          console.log('backupsToDelete', backupNamesToDelete);
 
           return storageService.delete(backupNamesToDelete);
         });

--- a/server/backend/services/backup.js
+++ b/server/backend/services/backup.js
@@ -74,8 +74,8 @@ module.exports = ({ strapi }) => {
     });
   
     // Select unique backups for weekly and monthly periods
-    const weeklyBackupsToKeep = getBackupsToKeep(weeklyBackups, 1800);
-    const monthlyBackupsToKeep = getBackupsToKeep(monthlyBackups, 3600);
+    const weeklyBackupsToKeep = getBackupsToKeep(weeklyBackups, 604800);
+    const monthlyBackupsToKeep = getBackupsToKeep(monthlyBackups, 2592000);
   
     const backupsToDelete = backups.filter(backupFile =>
       !dailyBackups.includes(backupFile) &&

--- a/server/configuration/config.js
+++ b/server/configuration/config.js
@@ -31,7 +31,8 @@ const requiredConfigKeys = [
   'pgDumpExecutable',
   'sqlite3Executable',
   'storageService',
-  'timeToKeepBackupsInSeconds'
+  'timeToKeepBackupsInSeconds',
+  'cleanupPolicies'
 ];
 
 const configStorageServiceIsAwsS3 = config => config.storageService === StorageService.AWS_S3;
@@ -163,11 +164,25 @@ const customValidatorByRequiredConfigKey = {
     }
   },
   timeToKeepBackupsInSeconds: (config) => {
-    if (config.cleanup !== true)
+    if (config.allowCleanup !== true)
+      return;
+
+    if (typeof config.cleanupPolicies?.days === 'number')
       return;
 
     if (typeof config.timeToKeepBackupsInSeconds !== 'number') {
       throwConfigInvalidValueError('timeToKeepBackupsInSeconds', config.timeToKeepBackupsInSeconds);
+    }
+  },
+  cleanupPolicies: (config) => {
+    if (config.allowCleanup !== true)
+      return;
+
+    if (typeof config.cleanupPolicies?.days !== 'number' && typeof config.timeToKeepBackupsInSeconds === 'number')
+      return;
+
+    if (typeof config.cleanupPolicies?.days !== 'number') {
+      throwConfigInvalidValueError('cleanupPolicies', config.cleanupPolicies);
     }
   }
 }
@@ -181,6 +196,7 @@ module.exports = {
     pgDumpOptions: [],
     allowCleanup: false,
     timeToKeepBackupsInSeconds: undefined,
+    cleanupPolicies: {},
     cleanupCronSchedule: undefined,
     customDatabaseBackupFilename: undefined,
     customUploadsBackupFilename: undefined,


### PR DESCRIPTION
When using the cleanup function, a hard time cap for the backups to be deleted is limiting.
The possibility for the new setting `cleanupPolicies` in the config will add retention so that backups can be kept for a longer time without flooding the storage. It's still possible to set the hard cut when only using the `days` option. With the `weeks` and `months` options user can additionaly define how long a backup will be kept per week/month after the first period where every backup made is kept.

Also the old `timeToKeepBackupInSeconds`option is still supported but marked as deprecated.